### PR TITLE
Correção do id incorreto ao solicitar um compartilhamento

### DIFF
--- a/aplicacao/alocacao-professores/src/main/java/ufc/quixada/npi/ap/controller/OfertaController.java
+++ b/aplicacao/alocacao-professores/src/main/java/ufc/quixada/npi/ap/controller/OfertaController.java
@@ -277,8 +277,8 @@ public class OfertaController {
 		return compartilhamentoService.importarOfertasCompartilhadas(compartilhamentos, periodoAtivo, curso);
 	}
 	
-	@RequestMapping(path = {"/{id}/solicitar-compartilhamento"}, method = RequestMethod.GET)
-	public ModelAndView cadastrarCompartilhamento(@PathVariable("id") Integer id, @ModelAttribute("compartilhamento") Compartilhamento compartilhamento, Authentication auth){
+	@RequestMapping(path = {"/{idOferta}/solicitar-compartilhamento"}, method = RequestMethod.GET)
+	public ModelAndView cadastrarCompartilhamento(@PathVariable("idOferta") Integer id, @ModelAttribute("compartilhamento") Compartilhamento compartilhamento, Authentication auth){
 		ModelAndView modelAndView = new ModelAndView(Constants.COMPARTILHAMENTO_CADASTRAR);
 
 		Pessoa pessoa = (Pessoa) auth.getPrincipal();
@@ -289,8 +289,8 @@ public class OfertaController {
 		return modelAndView;
 	}
 
-	@RequestMapping(path = {"/{id}/solicitar-compartilhamento"}, method = RequestMethod.POST)
-	public ModelAndView cadastrarCompartilhamento(@PathVariable("id") Integer id, @ModelAttribute("compartilhamento") @Valid Compartilhamento compartilhamento, BindingResult bindingResult, ModelAndView modelAndView, Authentication auth){
+	@RequestMapping(path = {"/{idOferta}/solicitar-compartilhamento"}, method = RequestMethod.POST)
+	public ModelAndView cadastrarCompartilhamento(@PathVariable("idOferta") Integer id, @ModelAttribute("compartilhamento") @Valid Compartilhamento compartilhamento, BindingResult bindingResult, ModelAndView modelAndView, Authentication auth){
 		compartilhamentoValidator.validate(compartilhamento, bindingResult);
 
 		Pessoa pessoa = (Pessoa) auth.getPrincipal();


### PR DESCRIPTION
Alteração do nome da PathVariable de "id" para "idOferta", para que ela
não seja identificada como id do compartilhamento pelo Spring.